### PR TITLE
Feature/backend/#76

### DIFF
--- a/backend/models/Group.js
+++ b/backend/models/Group.js
@@ -9,6 +9,8 @@ const groupSchema = mongoose.Schema({
         required: true
     },
     inspectors: [{ type: Types.ObjectId, ref: 'User' }]
+}, {
+    versionKey: false
 });
 
 groupSchema.statics.create = function(payload) {

--- a/backend/routes/api/group.js
+++ b/backend/routes/api/group.js
@@ -2,6 +2,12 @@ const express = require('express');
 const router = express.Router();
 const groupController = require('../../controllers/groupController.js');
 
+router.get('', groupController.searchAll);
+router.get('/:group*', groupController.search);
+router.post('/:group*', groupController.create);
+router.put('/:group*', groupController.update);
+router.delete('/:group*', groupController.delete);
+
 /**
  * @swagger
  *  /group:
@@ -29,7 +35,7 @@ const groupController = require('../../controllers/groupController.js');
  *        500:
  *          description: Interner Server Error
  */
-router.get('', groupController.search);
+
 
 /**
  * @swagger
@@ -83,7 +89,7 @@ router.get('', groupController.search);
  *        500:
  *          description: Interner Server Error
  */
-router.post('', groupController.create);
+
 
 /**
  * @swagger
@@ -137,7 +143,7 @@ router.post('', groupController.create);
  *        500:
  *          description: Interner Server Error
  */
-router.put('', groupController.update);
+
 
 /**
  * @swagger
@@ -179,6 +185,6 @@ router.put('', groupController.update);
  *        500:
  *          description: Interner Server Error
  */
-router.delete('', groupController.delete);
+
 
 module.exports = router;

--- a/backend/routes/api/jwt.js
+++ b/backend/routes/api/jwt.js
@@ -13,6 +13,7 @@ router.all('', (req, res, next) => {
 
         if(decoded) {
             res.locals.serviceNumber = decoded.serviceNumber;
+            res.locals.serviceNumber = decoded._id;
             next();
         } else {
             let error = new Error('Authentication Failed: unauthorized');

--- a/backend/routes/api/jwt.js
+++ b/backend/routes/api/jwt.js
@@ -4,6 +4,8 @@ const router = express.Router();
 const jwt = require('jsonwebtoken');
 const SECRET_KEY = "MY_SECRET_KEY";
 
+const { Types } = require('mongoose');
+
 const { AuthError } = require('../../services/errors/BusinessError');
 
 router.all('', (req, res, next) => {
@@ -13,13 +15,14 @@ router.all('', (req, res, next) => {
 
         if(decoded) {
             res.locals.serviceNumber = decoded.serviceNumber;
-            res.locals.serviceNumber = decoded._id;
+            res.locals._id = Types.ObjectId(decoded._id);
             next();
         } else {
             let error = new Error('Authentication Failed: unauthorized');
             res.status(error.status || 500).send(error.message);
         }
     } catch(err) {
+        console.log(err);
         if(err instanceof AuthError) {
             res.status(err.status || 500).send(err.message);
         } else {

--- a/backend/services/errors/BusinessError.js
+++ b/backend/services/errors/BusinessError.js
@@ -22,7 +22,7 @@ class ForbiddenError extends BusinessError {
     }
 }
 
-class NotFounndError extends BusinessError {
+class NotFoundError extends BusinessError {
     constructor(message) {
         super(message);
         this.status = 404;
@@ -30,4 +30,4 @@ class NotFounndError extends BusinessError {
     }
 }
 
-module.exports = { BusinessError, AuthError, ForbiddenError, NotFounndError };
+module.exports = { BusinessError, AuthError, ForbiddenError, NotFoundError };

--- a/backend/services/groupService.js
+++ b/backend/services/groupService.js
@@ -3,9 +3,9 @@ const { MongoError } = require('mongoose');
 const { RuntimeError } = require('./errors/RuntimeError.js');
 
 module.exports = {
-	search: async (query) => {
+	search: async (path) => {
         try {
-            let regex = new RegExp(query);
+            let regex = new RegExp(path);
             let result = await Group.find({ path: regex })
                 .populate('admins', {
                     id: true, serviceNumber: true, name: true, rank: true,


### PR DESCRIPTION
- [ ] Fixed typo `NotFounndError` to `NotFoundError`
- [ ] jwt save ObjectId(user._id) at res.locals._id
- [ ] `/group` get values instead of body with params

I think the REST API should be intuitive. With this change, the API shows their resources in the URI.
Now you can get resources with URI, instead of the request body.

Some minor errors are also fixed.