### PR TITLE
Fix: Post /user 매핑 라우터 변경 #82

### DIFF
--- a/backend/routes/api/user.js
+++ b/backend/routes/api/user.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const userController = require('../../controllers/userController.js');
 
 router.get('', userController.search);
-router.post('', userController.save);
 
 router.get('/:id', (req, res) => {
     userService.findAll(req.params.id)

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/authController.js');
+const userController = require('../controllers/userController.js');
+
 const { init } = require('../InitDB.js');
 
 router.get('/', (req, res) => {
@@ -20,6 +22,7 @@ router.get('/initDB', (req, res) => {
 })
 
 router.post('/login', authController.login);
+router.post('/user', userController.save);
 
 
 module.exports = router;


### PR DESCRIPTION
문제점: 회원가입 시에 post  /user 로  전송을 하는데
user/* 은 전부 토큰 발행 이후에 접근이 가능해서
비회원인 사람이 회원가입을 진행불가

해결방안: URL을 매핑하는 라우터를 user에서 index로 변경

#### index.js
```
const express = require('express');
const router = express.Router();
const authController = require('../controllers/authController.js');
const userController = require('../controllers/userController.js');

const { init } = require('../InitDB.js');

router.get('/', (req, res) => {
    res.redirect('https://github.com/osamhack2021/Web_Handover_Handover/wiki/API-Reference');
});

router.get('/favicon.ico', (req, res) => { res.status(200).send('oK') })

router.get('/initDB', (req, res) => {
    try {
        init();
        res.status(200).send('OK');
    } catch(e) {
        console.log(e)
        res.send(e);
    }
})

router.post('/login', authController.login);
router.post('/user', userController.save);


module.exports = router;
```

#### user.js
```
const express = require('express');
const router = express.Router();
const userController = require('../../controllers/userController.js');

router.get('', userController.search);

router.get('/:id', (req, res) => {
    userService.findAll(req.params.id)
        .then(result => res.send(result));
});

router.put('/:id', userController.updateUser);
router.delete('/:id', userController.deleteUser);

module.exports = router;
```