### PR TITLE
Fix: Update deprecated API usage #106

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -46,7 +46,7 @@ userSchema.statics.updateByid = function(id, payload) {
 };
 
 userSchema.statics.deleteByid = function(id) {
-    return this.remove({ id });
+    return this.deleteOne({ id });
 };
 
 


### PR DESCRIPTION
```
[MONGODB DRIVER] Warning: collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.
```

remove() 에서 deleteOne()으로 변경