### PR TITLE
Remove: response empty array instead of 404 error

### DIFF
--- a/backend/controllers/groupController.js
+++ b/backend/controllers/groupController.js
@@ -18,8 +18,6 @@ module.exports = {
 
             const result = await groupService.search(req.query);
 
-            if(result.length < 1) throw new NotFoundError(`NotFound: 검색결과가 없습니다.`);
-
             res.status(200).send(result);
         } catch(err) {
             res.status(err.status || 500).send(err.message);

--- a/backend/controllers/itemController.js
+++ b/backend/controllers/itemController.js
@@ -21,8 +21,6 @@ module.exports = {
 
             const result = await itemService.search(req.query);
 
-            if(result.length < 1) throw new NotFoundError(`Not Found: 검색결과가 없습니다.`);
-
             res.status(200).send(result);
 
         } catch(err) {
@@ -38,8 +36,6 @@ module.exports = {
             const result = await algolia.search(query, {
                 filters: `status:"modified" AND NOT accessGroups.read:"${res.locals.group}"`
             });
-
-            if(result.hits.length < 1) throw new NotFoundError(`NotFound: 검색결과가 없습니다.`);
 
             res.status(200).send(result.hits);
         } catch(err) {


### PR DESCRIPTION
When API serves Array like in searching resources,
response empty array instead of 404 error.

Resolved: #178